### PR TITLE
chore: rename psp-js → DreamCart + dreamcart.games site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 .pspjs-*.workflow.js
 dist-3ds
 web/games.generated.js
+web/site
 runtime-3ds/build
 runtime-3ds/source/game_js.h
 runtime-3ds/*.3dsx

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PSP.js
+# DreamCart
 An **isomorphic** JavaScript game runtime — the *same* game `.js` runs unchanged on
 Sony **PSP**, the **Web**, and Nintendo **3DS**, powered by [QuickJS](https://bellard.org/quickjs/)
 (plus [rust-psp](https://github.com/overdrivenpotato/rust-psp) on PSP and
@@ -135,8 +135,8 @@ Install [Bun](https://bun.sh) and [Homebrew](https://brew.sh) (and Docker, e.g.
 **everything**:
 
 ``` sh
-git clone https://github.com/doodlewind/psp-js.git
-cd psp-js
+git clone https://github.com/doodlewind/dreamcart.git
+cd dreamcart
 bun install
 bun run bootstrap
 ```
@@ -190,7 +190,7 @@ Builds a `.3dsx` homebrew app using the `devkitpro/devkitarm` Docker image — n
 host toolchain install or sudo needed (just Docker, e.g. OrbStack/Docker Desktop):
 
 ``` sh
-PSPJS_GAME=raw-tetris.js bun run 3ds   # -> runtime-3ds/psp-js-3ds.3dsx
+PSPJS_GAME=raw-tetris.js bun run 3ds   # -> runtime-3ds/dreamcart-3ds.3dsx
 ```
 
 Run the `.3dsx` in [Azahar](https://azahar-emu.org/) (the maintained Citra fork)

--- a/framework/games/flappy.js
+++ b/framework/games/flappy.js
@@ -2,7 +2,7 @@
 // @title Flappy
 // @order 3
 // @controls CROSS / UP to flap; START restart
-// flappy.js — a Flappy-Bird clone for the psp-js framework.
+// flappy.js — a Flappy-Bird clone for the DreamCart framework.
 // Bird stays at a fixed x with gravity; CROSS/Up flaps. Pipes scroll left;
 // passing a pipe scores. Hitting a pipe / ground / ceiling ends the game.
 import {

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -1,4 +1,4 @@
-// Public API of the psp-js game framework. Games import from here and are
+// Public API of the DreamCart game framework. Games import from here and are
 // bundled (with the framework inlined) per platform by framework/build.ts (Bun.build).
 import './assets-font'; // registers the default font (side effect: setFont)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "psp-js",
+  "name": "dreamcart",
   "private": true,
   "type": "module",
   "description": "Isomorphic JS game runtime + framework for PSP, Web and 3DS. All scripts run on Bun.",
@@ -9,6 +9,8 @@
     "play": "bun scripts/play.ts",
     "serve": "bun web/serve.ts",
     "web": "bun web/build-games.ts",
+    "site": "bun web/deploy-build.ts",
+    "deploy": "bun web/deploy-build.ts && bunx wrangler pages deploy web/site --project-name dreamcart",
     "bake": "bun framework/bake/bake-font.ts && bun framework/bake/bake-sprites.ts",
     "typecheck": "bunx tsc -p framework/tsconfig.json --noEmit && bunx tsc -p framework/games/tsconfig.json --noEmit",
     "bundle": "bun framework/build.ts",

--- a/runtime-3ds/Makefile
+++ b/runtime-3ds/Makefile
@@ -10,7 +10,7 @@ TOPDIR ?= $(CURDIR)
 include $(DEVKITARM)/3ds_rules
 
 #---------------------------------------------------------------------------------
-TARGET		:=	psp-js-3ds
+TARGET		:=	dreamcart-3ds
 BUILD		:=	build
 SOURCES		:=	source quickjs
 DATA		:=	data

--- a/runtime-3ds/build.ts
+++ b/runtime-3ds/build.ts
@@ -10,5 +10,5 @@ const IMG = "devkitpro/devkitarm:latest";
 console.log("3DS build: " + game);
 await $`bun ${here}gen-game.ts ${game}`;
 await $`docker run --rm -v ${root.replace(/\/$/, "")}:/work -w /work/runtime-3ds ${IMG} bash -lc ${"make -j8"}`;
-console.log("output: runtime-3ds/psp-js-3ds.3dsx");
-await $`file ${here}psp-js-3ds.3dsx`;
+console.log("output: runtime-3ds/dreamcart-3ds.3dsx");
+await $`file ${here}dreamcart-3ds.3dsx`;

--- a/scripts/bootstrap.ts
+++ b/scripts/bootstrap.ts
@@ -31,7 +31,7 @@ async function run(p: ReturnType<typeof $>): Promise<boolean> {
   return r.exitCode === 0;
 }
 
-console.log("psp-js environment setup (" + arch + ")\n");
+console.log("DreamCart environment setup (" + arch + ")\n");
 
 // 1) Bun deps
 console.log("deps:");

--- a/scripts/play.ts
+++ b/scripts/play.ts
@@ -74,7 +74,7 @@ if (platform === "web") {
   if (isFw(game)) await ensureBundles();
   console.log("building 3DS .3dsx for " + game + " ...");
   await $`bun ${root}runtime-3ds/build.ts`.env({ ...process.env, PSPJS_GAME: game + ".js" });
-  const dsx = root + "runtime-3ds/psp-js-3ds.3dsx";
+  const dsx = root + "runtime-3ds/dreamcart-3ds.3dsx";
   const dirs = ["/Applications", `${process.env.HOME}/Applications`];
   let emuApp = "";
   for (const e of ["Azahar", "Lime3DS", "Citra", "Panda3DS"]) {

--- a/web/deploy-build.ts
+++ b/web/deploy-build.ts
@@ -1,0 +1,26 @@
+// Assembles web/site/ — the directory deployed to Cloudflare Pages (dreamcart.games).
+//   /            -> WIP landing page (web/landing.html), reveals nothing.
+//   /play/       -> the DreamCart Playground (the simulator), fully functional.
+// Run: bun web/deploy-build.ts
+import { rm, mkdir, copyFile } from "node:fs/promises";
+import { buildGames } from "./build-games.ts";
+
+const here = new URL(".", import.meta.url).pathname; // the web/ dir
+const out = here + "site/";
+const play = out + "play/";
+
+// Always refresh the game manifest so the deployed simulator is current.
+const n = await buildGames();
+
+await rm(out, { recursive: true, force: true });
+await mkdir(play, { recursive: true });
+
+// Landing (WIP) at the root.
+await copyFile(here + "landing.html", out + "index.html");
+
+// Simulator + its assets under /play/.
+for (const f of ["index.html", "engine.js", "games.generated.js"]) {
+  await copyFile(here + f, play + f);
+}
+
+console.log(`web/site assembled: WIP landing at /, simulator at /play/ (${n} games)`);

--- a/web/engine.js
+++ b/web/engine.js
@@ -1,4 +1,4 @@
-// psp-js Web engine — an isomorphic Canvas implementation of the same tiny
+// DreamCart Web engine — an isomorphic Canvas implementation of the same tiny
 // runtime the PSP and 3DS builds provide. A game is a .js file that uses only:
 //   gfx.clear(r,g,b), gfx.fillRect(x,y,w,h,r,g,b), log(msg)
 //   globalThis.frame = function(buttons){ ... }   // called ~60x/second

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>psp-js Playground</title>
+<title>DreamCart Playground</title>
 <style>
   :root { --bg:#0f1117; --panel:#171a23; --line:#262b38; --fg:#e6e8ee; --muted:#8b93a7; --accent:#5ee08a; }
   * { box-sizing: border-box; }
@@ -42,7 +42,7 @@
 </head>
 <body>
 <header>
-  <h1><b>psp-js</b> Playground</h1>
+  <h1><b>DreamCart</b> Playground</h1>
   <span class="sub">the same JS games that run on PSP &amp; 3DS, in your browser</span>
 </header>
 

--- a/web/landing.html
+++ b/web/landing.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>DreamCart</title>
+<meta name="robots" content="noindex, nofollow" />
+<style>
+  :root { --bg:#0f1117; --fg:#e6e8ee; --muted:#5b6477; --accent:#5ee08a; }
+  * { box-sizing: border-box; }
+  html, body { margin:0; height:100%; }
+  body {
+    background: var(--bg); color: var(--fg);
+    font: 14px/1.6 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    display: flex; align-items: center; justify-content: center;
+    min-height: 100vh; text-align: center; padding: 24px;
+    background-image: radial-gradient(circle at 50% 38%, #161a24 0%, var(--bg) 60%);
+  }
+  .wm { font-size: clamp(34px, 8vw, 60px); font-weight: 700; letter-spacing: -0.02em; margin: 0; }
+  .wm b { color: var(--accent); font-weight: 700; }
+  .cursor { display:inline-block; width:0.55ch; background:var(--accent); margin-left:2px;
+    animation: blink 1.1s steps(1) infinite; }
+  @keyframes blink { 50% { opacity: 0; } }
+  .tag { margin-top: 18px; color: var(--muted); font-size: 13px; text-transform: uppercase; letter-spacing: 0.28em; }
+</style>
+</head>
+<body>
+  <main>
+    <h1 class="wm">Dream<b>Cart</b><span class="cursor">&nbsp;</span></h1>
+    <p class="tag">Work in progress</p>
+  </main>
+</body>
+</html>

--- a/web/serve.ts
+++ b/web/serve.ts
@@ -1,4 +1,4 @@
-// Bun.serve static server for the psp-js Playground.
+// Bun.serve static server for the DreamCart Playground.
 //   bun web/serve.ts            -> http://localhost:8123
 //   PORT=3000 bun web/serve.ts
 // Regenerates web/games.generated.js on startup so the manifest is always fresh.
@@ -33,7 +33,7 @@ export async function startServer(port = Number(process.env.PORT ?? 8123)) {
     },
   });
 
-  console.log("psp-js Playground -> http://localhost:" + server.port + "/");
+  console.log("DreamCart Playground -> http://localhost:" + server.port + "/");
   console.log("  pick a game:        http://localhost:" + server.port + "/?game=rpg.js");
   return server;
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  // Cloudflare Pages config for the dreamcart.games site.
+  // Deploy with: bun run deploy   (assembles web/site, then `wrangler pages deploy`)
+  "name": "dreamcart",
+  "compatibility_date": "2025-06-15",
+  "pages_build_output_dir": "web/site"
+}


### PR DESCRIPTION
Renames the project to **DreamCart** (branding/README/Playground/3DS artifact; internal `PSPJS` global left as-is) and adds the Cloudflare Pages site served at **dreamcart.games**: a WIP-only landing at `/` and the simulator at `/play/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)