### PR TITLE
[codex] reduce PSP abicalls linker warnings

### DIFF
--- a/runtime/build.ts
+++ b/runtime/build.ts
@@ -25,8 +25,10 @@ const env = {
   CRATE_CC_NO_DEFAULTS: "1",
   TARGET_CC: "clang",
   TARGET_AR: `${llvm}/llvm-ar`,
+  // Match the Rust PSP target's +noabicalls mode. -G0 avoids clang's MIPS
+  // backend selecting unsupported GP-relative accesses for large C sources.
   TARGET_CFLAGS:
-    `-target mipsel-sony-psp -mcpu=mips2 -msingle-float -mlittle-endian -mno-check-zero-division ` +
+    `-target mipsel-sony-psp -mcpu=mips2 -msingle-float -mlittle-endian -mno-abicalls -fno-pic -G0 -mno-check-zero-division ` +
     `-fno-stack-protector -I${sdk}/psp/include -I${sdk}/psp/sdk/include`,
   // CRITICAL: archive MIPS objects with llvm-ar (Apple ar drops them -> undefined JS_*).
   AR_mipsel_sony_psp: `${llvm}/llvm-ar`,


### PR DESCRIPTION
## Summary
- align PSP C compilation flags with the Rust target's `+noabicalls` mode
- add `-mno-abicalls -fno-pic -G0` for QuickJS C objects so runtime-built C code no longer contributes `cpic` linker warnings
- document why `-G0` is required with clang's MIPS backend for larger C sources

## Validation
- `bun run typecheck`
- `bun play psp adventure3d`
- `llvm-readelf -h quickjs.o` shows `Flags: 0x10001001, noreorder, o32, mips2` without `cpic`

## Notes
Remaining `linking abicalls code with non-abicalls code` warnings come from prebuilt `rust-psp/psp/libunwind.a` and PSPSDK/newlib objects such as `lib_a-dtoa.o`, not from the QuickJS objects compiled by this repo.