### PR TITLE
[codex] Use normalized PSP SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ and installs/configures:
 - **Azahar** (downloaded from GitHub releases) — 3DS emulator
 - **Rust** `nightly-2026-05-28` + `rust-src`, and pins the repo override
 - **cargo-psp / prxgen / pack-pbp / mksfo** (built from the `rust-psp` submodule)
-- the **PSPSDK** (prebuilt newlib) into `mipsel-sony-psp/`
+- the **PSPSDK** from `doodlewind/pspdev`
+  (`sdk-noabicalls-normalized-2026-06-19`, clang-built no-abicalls newlib/glue
+  with normalized archive metadata) into `mipsel-sony-psp/`
 - the **`devkitpro/devkitarm`** Docker image (3DS toolchain)
 
 It reports anything it can't auto-install (Homebrew/Docker not present, Docker

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Yifeng Wang <doodlewind@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-psp = { path = "../rust-psp/psp", features = ["external-c-heap"] }
+psp = { path = "../rust-psp/psp", features = ["external-c-heap", "abort-only"] }
 libquickjs-sys = { path = "../quickjs-rs/libquickjs-sys" }
 linked_list_allocator = { version = "=0.9.1", default-features = false }
 

--- a/runtime/build.ts
+++ b/runtime/build.ts
@@ -34,6 +34,9 @@ const env = {
   AR_mipsel_sony_psp: `${llvm}/llvm-ar`,
   RANLIB_mipsel_sony_psp: `${llvm}/llvm-ranlib`,
   RUST_PSP_TARGET: pspTarget,
+  // Dreamcart runs panic-abort on PSP; this avoids building/linking
+  // panic_unwind + libunwind into no_std EBOOTs.
+  RUST_PSP_ABORT_ONLY: "1",
   // Keep PSP dev builds fast without reviving the old RUSTFLAGS workaround that
   // mixed opt-level with link-dead-code and triggered noisy MIPS relocations.
   CARGO_PROFILE_DEV_OPT_LEVEL: process.env.CARGO_PROFILE_DEV_OPT_LEVEL ?? "3",

--- a/scripts/bootstrap.ts
+++ b/scripts/bootstrap.ts
@@ -2,9 +2,9 @@
 // step checks first and skips if already done. Run: bun run bootstrap
 //
 // Sets up: bun deps, submodules, LLVM, PPSSPP, Azahar (3DS emulator),
-// Rust nightly + rust-src, cargo-psp/prxgen/pack-pbp/mksfo, the PSPSDK, and the
-// devkitARM docker image. Prereqs it can't auto-install (Bun, Homebrew, Docker
-// daemon) are detected and reported.
+// Rust nightly + rust-src, cargo-psp/prxgen/pack-pbp/mksfo, the normalized
+// no-abicalls PSPSDK, and the devkitARM docker image. Prereqs it can't
+// auto-install (Bun, Homebrew, Docker daemon) are detected and reported.
 import { $ } from "bun";
 import { existsSync } from "node:fs";
 
@@ -91,17 +91,17 @@ if (!cargo && !rustup) {
     ? await run($`${rustup} run stable cargo build --release --bins`.cwd(root + "rust-psp/cargo-psp"))
     : await run($`${cargo} build --release --bins`.cwd(root + "rust-psp/cargo-psp"));
   if (built) {
-    for (const t of tools) await run($`cp ${root}rust-psp/target/release/${t} ${home}/.cargo/bin/${t}`);
+    for (const t of tools) await run($`cp ${root}rust-psp/cargo-psp/target/release/${t} ${home}/.cargo/bin/${t}`);
     rec("cargo-psp tools", "ok");
   } else rec("cargo-psp tools", "fail", "build failed");
 }
 
-// 7) PSPSDK (prebuilt newlib)
+// 7) PSPSDK (clang-built no-abicalls newlib/glue + normalized archive metadata)
 console.log("pspsdk:");
 if (existsSync(root + "mipsel-sony-psp/psp/lib/libc.a")) {
   rec("PSPSDK", "skip");
 } else {
-  const url = "https://github.com/doodlewind/psp-test-app/releases/download/sdk/mipsel-sony-psp.zip";
+  const url = "https://github.com/doodlewind/pspdev/releases/download/sdk-noabicalls-normalized-2026-06-19/mipsel-sony-psp.zip";
   const okDl = await run($`curl -fsSL -o /tmp/psp-sdk.zip ${url}`);
   const okUz = okDl && (await run($`unzip -q -o /tmp/psp-sdk.zip -d ${root}`));
   rec("PSPSDK", okUz ? "ok" : "fail");


### PR DESCRIPTION
## Summary

- switch bootstrap to the normalized no-abicalls PSP SDK release from `doodlewind/pspdev`
- update the `rust-psp` submodule to the abort-only panic mode commit and enable the `abort-only` PSP feature
- export `RUST_PSP_ABORT_ONLY=1` for PSP builds so cargo-psp excludes `panic_unwind` from build-std
- fix bootstrap's cargo-psp tool copy path so it installs the binaries it just built from `rust-psp/cargo-psp`

## Why

The PSP toolchain warnings were coming from real ABI/linker mismatches in the prebuilt SDK and panic unwind path. The new SDK is built from the doodlewind PSPDEV fork with normalized archive metadata, no-abicalls target libraries, and a restored `libpthread-psp.a` compatibility archive for consumers linking `-lpthread-psp`.

## Validation

- `bun scripts/bootstrap.ts` from a removed local `mipsel-sony-psp/` directory; downloaded release asset SHA-256 `fc7d7d502d53987f356871bc8c58396fb0f2a6eb6f5828b16c3bc3f22991a273`
- verified downloaded SDK has Mach-O arm64 PSP tools and both `libpthread.a` / `libpthread-psp.a`
- `env -u PSPJS_SUPPRESS_LINKER_MESSAGES bun play psp adventure3d`
- scanned the final adventure3d build log for PSP ABI/linker warnings and errors; no matches
- verified PPSSPP window shows `TACTICAL 3D` at `60 FPS`
- `bun run test`
- `bun run typecheck`
