### PR TITLE
Cleanup: unify AABB type + drop dead bsp-walk export (post-#25 review)

### DIFF
--- a/framework/bake/bake-scene.ts
+++ b/framework/bake/bake-scene.ts
@@ -16,7 +16,7 @@
 //   bun framework/bake/bake-scene.ts
 import { readdirSync, existsSync } from 'node:fs';
 import { pack, unpack, rawBytes, DT_U8, DT_F32, type Blob } from './dcpak';
-import type { SceneDescriptor, MeshProto } from '../src/scene-desc';
+import type { SceneDescriptor, MeshProto, AABBDesc } from '../src/scene-desc';
 
 const here = new URL('.', import.meta.url).pathname;
 const scenesDir = here + '../scenes/';
@@ -28,7 +28,7 @@ interface SceneMeta {
   fog?: SceneDescriptor['fog'];
   prototypes: Record<string, MeshProto>;
   entities: { proto?: string; box?: { size: [number, number, number]; colors: number[] };
-              bounds?: { min: [number, number, number]; max: [number, number, number] };
+              bounds?: AABBDesc;
               tint?: number; isStatic?: boolean; id?: string;
               hasPos: boolean; hasRot: boolean; hasScale: boolean; hasMatrix?: boolean }[];
   instances: { proto: string; count: number; tint?: number; isStatic?: boolean;

--- a/framework/src/bsp-walk.ts
+++ b/framework/src/bsp-walk.ts
@@ -51,8 +51,9 @@ export function blocked(aabbs: Float32Array, nx: number, nz: number): boolean {
   return false;
 }
 
-/** Axis-separated move (slide along walls), clamped to the map span. */
-export function moveTo(st: WalkState, aabbs: Float32Array, span: number, nx: number, nz: number): void {
+/** Axis-separated move (slide along walls), clamped to the map span. Internal to
+ *  walkStep — not part of the public API (callers use walkStep). */
+function moveTo(st: WalkState, aabbs: Float32Array, span: number, nx: number, nz: number): void {
   const lim = span;
   if (nx > lim) nx = lim; else if (nx < -lim) nx = -lim;
   if (nz > lim) nz = lim; else if (nz < -lim) nz = -lim;

--- a/framework/src/scene-desc.ts
+++ b/framework/src/scene-desc.ts
@@ -29,7 +29,7 @@
 // node (matching racing3d's per-cone nodes, which keep the cone a single shared
 // upload drawn at many model matrices).
 import { Mesh, mergeMeshes } from './mesh';
-import { Scene3D, Node3D } from './scene3d';
+import { Scene3D, Node3D, type AABB } from './scene3d';
 import { Vec3, Quat, Mat4 } from './math';
 import { dcU8, dcF32 } from './dcpak';
 
@@ -76,7 +76,9 @@ export interface InstanceGroup {
   id?: string; // when merged, the id of the resulting single node
 }
 
-export interface AABBDesc { min: [number, number, number]; max: [number, number, number]; }
+// The descriptor-layer name for a world-space AABB; identical to scene3d's AABB
+// (the single canonical shape — kept as an alias so the two layers can't drift).
+export type AABBDesc = AABB;
 
 export interface SceneDescriptor {
   camera?: { fovDeg: number; aspect: number; near: number; far: number };


### PR DESCRIPTION
Systematic adversarial review of **#25** (the scene-format rotation refactor + adventure3d scene-ification) and the scene/controller/**BSP** architecture boundaries (now that the BSP map system landed in parallel).

**Result: 24 findings raised, only 2 confirmed** real *and* worth fixing. Notably, the feared **scene-desc ↔ BSP boundary drift was dismissed** by the verifiers — the two collision/scene representations are legitimately distinct (different problem domains), so a documented boundary is correct, not decay. The architecture is sound.

The 2 byte-exact fixes:
- **AABB type drift** (medium): `scene-desc.AABBDesc` and `bake-scene`'s inline `{min,max}` were structural duplicates of `scene3d`'s canonical `AABB`. `AABBDesc` is now `= AABB` (imported); bake-scene's `SceneMeta.bounds` uses `AABBDesc`. Single canonical shape, no drift.
- **Dead export** (low): `bsp-walk.ts moveTo()` was exported but used only internally by `walkStep()` (nothing imports it). Dropped the `export`.

Both are type-only / dead-export removals. `bun run test`: **24 golden + bsp-parse/bake/walk/gen + controller/action/scene-desc suites all byte-identical**; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)