### PR TITLE
feat(bsp): adaptive guard-band tessellation for real maps (budget-aware)

### DIFF
--- a/framework/bake/bake-bsp.ts
+++ b/framework/bake/bake-bsp.ts
@@ -32,8 +32,9 @@ interface MapConf {
   sky: number;
   committed: boolean; // box: commit the module; c1a0: gitignored (Valve-derivative)
   tess?: number; // subdivide faces so no triangle edge exceeds this many metres (PSP GE
-  // guard-band safety for coarse fixtures viewed up close). Omitted for real maps (their
-  // geometry is already fine-grained) so their bake output is unchanged.
+  // guard-band safety: a single huge wall triangle projects far off-screen up close and the
+  // GE drops it). Set explicitly for coarse fixtures (box/zfight = 1.0); when UNSET (real
+  // maps) it defaults to an adaptive clamp(span*0.08, 2, 8) m — see below.
 }
 
 const ROOT = new URL('../../', import.meta.url).pathname;
@@ -190,6 +191,13 @@ for (const fo of visible) {
 }
 const cX = (minX + maxX) / 2, cZ = (minZ + maxZ) / 2;
 const span = Math.max(maxX - minX, maxZ - minZ) / 2 + 2;
+// Real maps (M.tess unset) get an ADAPTIVE guard-band tess that scales with map span: a
+// large map (de_dust2, span ~69) subdivides only its biggest faces (edge > ~8 m); a small
+// room subdivides finely (clamped to 2 m). Clamped [2, 8] m so byte growth stays bounded —
+// 8 m on dust2 was empirically the finest that adds NO extra decimation (the big walls/
+// floors split a level, all 156 sub-meshes + small detail kept, pack stays under budget).
+// Coarse fixtures keep their explicit per-map tess (box/zfight = 1.0). BSP_TESS env overrides.
+if (M.tess === undefined) M.tess = process.env.BSP_TESS ? Number(process.env.BSP_TESS) : Math.max(2.0, Math.min(8.0, span * 0.12));
 const NC = M.chunks * M.chunks;
 const NT = texturesOut.length || 1;
 const slot = (ci: number, tx: number) => ci * NT + tx;


### PR DESCRIPTION
Extends face-tessellation (PR #26, which covered the CC0 box/zfight fixtures) to **real maps**, budget-aware.

## What
- When `MapConf.tess` is unset, default it to an adaptive **`clamp(span·0.12, 2, 8)` metres** — a large map (de_dust2, span 69 → 8 m) subdivides only its biggest faces; a small room subdivides finely. Coarse fixtures keep explicit `tess:1.0` (the `=== undefined` guard skips them → box/zfight bake **byte-identical**, goldens unchanged). `BSP_TESS` env overrides for tuning.

## Why 8 m (empirical, dust2 is already budget-constrained)
| tess | pack | sub-meshes | minArea | verdict |
|---|---|---|---|---|
| ∞ (baseline) | 1150 KB | 156 | 0.655 | — |
| 8 m | 1197 KB | 156 | 0.655 | **sweet spot: big faces split, ZERO extra decimation** |
| 7 m | 1175 KB | 155 | 1.049 | slight detail loss |
| 5.56 m | 0.91 MB | 100 | 6.872 | cliff — heavy small-face decimation |

So tess splits big faces; the existing `minArea` budget loop trims small ones (disjoint sets). 8 m keeps all detail under the 1.18 MB budget; EBOOT boots + renders.

## Scope (honest)
This gives real maps general guard-band robustness for large faces close-up. It does **not** fully resolve de_dust2's first-person *capture* band (poses 8-15/31, structIoU ~0.55): that's **grazing-floor guard-band clipping** — a floor seen edge-on projects feet-to-horizon however finely it's split — a fundamental PSP GE limit, unfixable within dust2's budget. It's a capture-camera artifact (third-person gameplay avoids grazing floor angles); walls/crates/arches match the software oracle exactly (structIoU 1.00 baseline).

## Verified
- typecheck clean; `bun run test` green (24 golden + bsp parse/bake/walk/gen; box/zfight byte-identical).
- Only `bake-bsp.ts` committed — dust2's baked module + private pack are gitignored (Valve-derivative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
