### PR TITLE
fix(web): remove dead hamburger menu button from nav

### DIFF
--- a/web/site-src/components/Nav.tsx
+++ b/web/site-src/components/Nav.tsx
@@ -4,7 +4,6 @@
  * plus the live ThemePicker. `active` highlights the current route.
  * Headless markup via data-part; styled in base.ts.
  */
-import { useState } from "react";
 import { ThemePicker } from "./ThemePicker";
 
 export type NavKey = "engine" | "play" | "docs" | "changelog" | null;
@@ -19,26 +18,13 @@ const LINKS: { key: Exclude<NavKey, null>; label: string; href: string }[] = [
 ];
 
 export function Nav({ active = null }: { active?: NavKey }) {
-  const [open, setOpen] = useState(false);
   return (
-    <nav data-part="nav" data-open={open} aria-label="Primary">
+    <nav data-part="nav" aria-label="Primary">
       <a data-part="nav-brand" href="/">
         <span data-part="nav-brand-mark">DC</span>
         DreamCart
       </a>
       <div data-part="nav-spacer" />
-      <button
-        type="button"
-        data-part="button"
-        data-nav-toggle="true"
-        data-variant="ghost"
-        data-size="sm"
-        aria-label="Menu"
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-      >
-        ☰
-      </button>
       <div data-part="nav-links">
         {LINKS.map((l) => (
           <a

--- a/web/site-src/styles/base.ts
+++ b/web/site-src/styles/base.ts
@@ -66,17 +66,10 @@ code, pre, kbd { font-family: var(--font-mono); }
 [data-part="nav-link"][data-icon="github"] { display: inline-flex; align-items: center; padding: 7px 9px; }
 [data-part="nav-link"][data-icon="github"] svg { display: block; }
 [data-part="nav-spacer"] { flex: 1; }
-[data-nav-toggle] { display: none; order: 3; }
 
 @media (max-width: 760px) {
-  [data-part="nav-links"] {
-    position: absolute; top: 58px; left: 0; right: 0; flex-direction: column;
-    align-items: stretch; gap: 0; padding: 8px; margin: 0;
-    background: var(--surface); border-bottom: 1px solid var(--border);
-  }
-  [data-part="nav"][data-open="false"] [data-part="nav-links"] { display: none; }
-  [data-part="nav-link"] { padding: 12px; border-radius: 8px; }
-  [data-nav-toggle] { display: inline-flex; }
+  [data-part="nav-links"] { flex-wrap: wrap; justify-content: flex-end; margin-left: 0; }
+  [data-part="nav-link"] { padding: 7px 8px; }
 }
 
 /* ── Theme picker ────────────────────────────────────────────────────────── */


### PR DESCRIPTION
The three-line (☰) menu button at the far right of the site nav did nothing when clicked on desktop — it was `display:none` there and only gated a mobile dropdown. This removes it.

## Changes
- **`Nav.tsx`** — drop the toggle `<button>`, the `open` `useState`, the `data-open` attribute, and the now-unused `useState` import.
- **`base.ts`** — remove the `[data-nav-toggle]` rules and the mobile "hide links behind toggle" logic. On ≤760px the nav links now wrap and stay visible (tighter padding) instead of disappearing.

## Verify
- `bun run site` builds clean (363 ms).
- No `☰` / `nav-toggle` remnants in `web/site` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)