### PR TITLE
Add real-PSP USB debug loop: bun run psp:hw

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ Copy `dist/psp-trace/PSP` to the root of the PSP memory stick. On PS Vita
 Adrenaline, the final path is
 `ux0:pspemu/PSP/GAME/dreamcart-raw-snake-trace/EBOOT.PBP`.
 
+### Debug on real PSP hardware over USB
+Run a freshly compiled game on an actual PSP in seconds — no memory-stick copy:
+
+``` sh
+bun run psp:hw walk3d   # build, then load onto the PSP; press Enter to hot-reload
+```
+
+It serves the cargo output to the PSP as `host0:` (usbhostfs) and `ldstart`s it
+through PSPLINK (pspsh), keeping a tight edit → build → run loop on real silicon.
+Needs a one-time host-tools + PSPLINK setup — see
+[`docs/psp-hardware-debugging.md`](docs/psp-hardware-debugging.md).
+
 ## Play (one command)
 `bun run play <web|psp|3ds> [game]` builds the chosen game and launches the
 matching emulator:

--- a/docs/psp-hardware-debugging.md
+++ b/docs/psp-hardware-debugging.md
@@ -1,0 +1,146 @@
+# Debugging on a real PSP over USB
+
+Run a freshly compiled DreamCart game on an actual PSP in a couple of seconds —
+straight from your cargo output, with **no copying files to the memory stick**.
+Edit code, press Enter, see it on the hardware.
+
+```sh
+bun run psp:hw walk3d
+```
+
+This drives the classic PSP homebrew debug chain (PSPLINK + usbhostfs) so you get
+a tight edit → build → run loop on real silicon, not just the emulator.
+
+## How it works (30 seconds)
+
+- **`usbhostfs_pc`** (runs on your Mac) exposes a directory — your cargo output —
+  to the PSP as the virtual drive `host0:` over USB.
+- **PSPLINK** (a small homebrew running on the PSP) loads and starts a module
+  directly from `host0:`. It stays resident underneath your game.
+- **`pspsh`** is the shell used to send PSPLINK commands (`ldstart`, `reset`).
+- Because PSPLINK stays resident, `reset` gives you a clean machine, and the next
+  `ldstart` runs your newly built `.prx`. `bun run psp:hw` automates all of this.
+
+## Prerequisites
+
+- A **PSP with custom firmware** (PRO / ARK / ME / …). CFW is what lets homebrew
+  and PSPLINK run at all.
+- A **data** USB cable. Many PSP / mini-USB cables are charge-only — see
+  [Troubleshooting](#troubleshooting).
+- macOS with Homebrew (the setup commands below are for macOS/Apple Silicon;
+  Linux is analogous but installs `usbhostfs_pc`/`pspsh` from your package
+  manager or the same source).
+
+## One-time setup
+
+### 1. Host tools — `usbhostfs_pc` and `pspsh`
+
+These are not in Homebrew; build the two clients from the pspdev `psplinkusb`
+source. `pspsh` links Homebrew `readline`, which is keg-only, so its paths are
+passed explicitly.
+
+```sh
+brew install libusb                       # readline is usually already present
+git clone https://github.com/pspdev/psplinkusb.git ~/code/psplinkusb
+
+make -C ~/code/psplinkusb/usbhostfs_pc
+make -C ~/code/psplinkusb/pspsh \
+  CPPFLAGS="-I$(brew --prefix readline)/include" \
+  LIBS="-L$(brew --prefix readline)/lib -lreadline"
+
+# put them on PATH
+ln -sf ~/code/psplinkusb/usbhostfs_pc/usbhostfs_pc /opt/homebrew/bin/
+ln -sf ~/code/psplinkusb/pspsh/pspsh             /opt/homebrew/bin/
+```
+
+Verify: `usbhostfs_pc -h` and `pspsh -h` should run.
+
+### 2. PSPLINK on the PSP
+
+Grab the prebuilt PSPLINK and copy it onto the memory stick. With the PSP
+connected in USB mass-storage mode (or its stick in a card reader):
+
+```sh
+curl -L -o /tmp/psplink.zip \
+  https://github.com/pspdev/psplinkusb/releases/latest/download/psplink.zip
+unzip /tmp/psplink.zip -d "/Volumes/<PSP_STICK>/PSP/GAME/"
+```
+
+That creates `PSP/GAME/psplink/` (EBOOT + `.prx` modules). Eject the stick.
+PSPLINK now appears in the PSP's **Game** menu.
+
+## Daily use
+
+```sh
+bun run psp:hw walk3d
+```
+
+Then on the PSP, launch **PSPLINK** from the XMB **Game** menu. The tool waits
+for the USB link, loads your game, and drops you into a reload prompt:
+
+- Press **Enter** to rebuild and reload the latest code.
+- Type **q** then Enter to quit.
+
+Other forms:
+
+```sh
+bun run psp:hw               # default game (raw-snake)
+bun run psp:hw walk3d -r     # release profile
+bun run psp:hw --once        # build + load once, then exit (CI / scripts)
+bun run psp:hw --no-build    # reload whatever is already built
+```
+
+No environment variables required. The tool auto-picks a free TCP port block for
+the link; override the starting port with `PSP_HW_PORT` if you ever need to.
+
+## Troubleshooting
+
+**"PSP never connected" / nothing shows up.**
+The Mac isn't seeing the PSP on USB at all. Check:
+```sh
+ioreg -p IOUSB | grep -i PSP     # should print: "PSP" Type B
+```
+If that prints nothing it is a hardware/cable issue, not software:
+- Use a **data** cable — many PSP cables only carry power. This is the most
+  common cause.
+- Plug directly into the Mac, not through a hub or dock.
+- The PSP sleeps when idle and drops the link; wake it and it reconnects
+  automatically (`usbhostfs_pc` re-prints `Connected to device`).
+
+**`bind: Address already in use`.**
+Something holds the default PSPLINK port (10000). `bun run psp:hw` auto-scans for
+a free block, but if you run the raw tools, give `usbhostfs_pc -b` / `pspsh -p` a
+different base port. (On this project's dev Mac, Baidu Netdisk squats on 10000.)
+
+**`ldstart … Error: 0x80020148` (`UNSUPPORTED_PRX_TYPE`).**
+You pointed `ldstart` at `EBOOT.PBP`. PSPLINK doesn't unwrap the PBP container —
+load the raw `pspjs-runtime.prx` instead. (`bun run psp:hw` already does this.)
+
+**`ldstart … Error: 0x800200D9` (`MEMBLOCK_ALLOC_FAILED`) when reloading.**
+The previous module didn't free its memory (rust-psp modules don't tear down on
+stop, so `modstun` + `ldstart` leaks). Always `reset` before re-loading. That's
+why `bun run psp:hw` resets between reloads.
+
+**Build fails with a missing SDK.**
+Run `bun run bootstrap` once for the checkout — git worktrees don't share the
+downloaded `mipsel-sony-psp/` SDK.
+
+## Doing it by hand
+
+If you want to drive the chain manually (or on Linux):
+
+```sh
+# serve the build directory to the PSP as host0:
+usbhostfs_pc -b 10200 runtime/target/mipsel-sony-psp/debug &
+
+# launch PSPLINK on the PSP, wait for "Connected to device", then:
+pspsh -p 10200 -e "ldstart host0:/pspjs-runtime.prx"    # load + run
+
+# after rebuilding (bun run psp):
+pspsh -p 10200 -e "reset"                                # clean reboot
+pspsh -p 10200 -e "ldstart host0:/pspjs-runtime.prx"     # run the new build
+```
+
+Handy PSPLINK commands over `pspsh -p <port> -e "<cmd>"`: `modlist` (list loaded
+modules), `ls host0:/` (list the served directory), `reset` (reboot PSPLINK),
+`ldstart <prx>` (load + start a module).

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "bun framework/test/contract.ts && bun framework/test/golden.ts",
     "build": "bun run bake && bun run typecheck && bun run bundle && bun run web",
     "psp": "bun runtime/build.ts",
+    "psp:hw": "bun scripts/psp-hw.ts",
     "psp:trace": "bun scripts/build-psp-trace.ts",
     "psp:all": "bun scripts/build-psp-all.ts",
     "3ds": "bun runtime-3ds/build.ts",

--- a/scripts/psp-hw.ts
+++ b/scripts/psp-hw.ts
@@ -1,0 +1,203 @@
+// Run a freshly compiled game on a REAL PSP over USB — no memory-stick copy.
+//
+//   bun run psp:hw               # build + run the default game on the PSP
+//   bun run psp:hw walk3d        # build + run a specific game
+//   bun run psp:hw walk3d -r     # release profile
+//   bun run psp:hw --once        # build + load once, then exit (CI / scripts)
+//   bun run psp:hw --no-build    # skip the build, just (re)load what's built
+//
+// It serves the cargo output directory to the PSP as `host0:` (usbhostfs_pc),
+// then `ldstart`s the raw `.prx` through PSPLINK (pspsh). PSPLINK stays resident,
+// so each reload is `reset` (clean memory) + `ldstart` (your latest build).
+//
+// One-time setup (host tools + PSPLINK on the stick): docs/psp-hardware-debugging.md
+import { $ } from "bun";
+import { existsSync, readdirSync } from "node:fs";
+import { createServer } from "node:net";
+import { createInterface } from "node:readline";
+
+const root = new URL("..", import.meta.url).pathname;
+const PRX = "host0:/pspjs-runtime.prx";
+
+const argv = Bun.argv.slice(2);
+const flags = new Set(argv.filter((a) => a.startsWith("-")));
+const positional = argv.filter((a) => !a.startsWith("-"));
+const release = flags.has("-r") || flags.has("--release");
+const once = flags.has("--once");
+const noBuild = flags.has("--no-build");
+const profile = release ? "release" : "debug";
+
+function listGames(): string[] {
+  const raw = readdirSync(root + "runtime/src/game").filter((f) => f.endsWith(".js")).map((f) => f.slice(0, -3));
+  const fw = readdirSync(root + "framework/games").filter((f) => f.endsWith(".js")).map((f) => f.slice(0, -3));
+  return Array.from(new Set([...raw, ...fw])).sort();
+}
+function resolveGame(name?: string): string | null {
+  if (!name) return null;
+  const n = name.replace(/\.(js|ts)$/, "");
+  return listGames().includes(n) ? n : null;
+}
+const isFw = (n: string) => existsSync(root + "framework/games/" + n + ".js");
+
+function usage(): void {
+  console.log("Usage: bun run psp:hw [game] [-r|--release] [--once] [--no-build]\n");
+  console.log("Runs a freshly compiled game on a real PSP over USB (PSPLINK + usbhostfs).");
+  console.log("Launch PSPLINK on the PSP from the XMB Game menu when prompted.\n");
+  console.log("Games: " + listGames().join(", "));
+}
+
+if (flags.has("-h") || flags.has("--help")) {
+  usage();
+  process.exit(0);
+}
+
+const game = resolveGame(positional[0]) ?? "raw-snake";
+if (positional[0] && !resolveGame(positional[0])) {
+  console.error("unknown game: " + positional[0]);
+  usage();
+  process.exit(1);
+}
+
+const usbhostfs = Bun.which("usbhostfs_pc");
+const pspsh = Bun.which("pspsh");
+if (!usbhostfs || !pspsh) {
+  console.error("PSPLINK host tools not found on PATH (need usbhostfs_pc and pspsh).");
+  console.error("One-time setup: docs/psp-hardware-debugging.md");
+  process.exit(1);
+}
+
+if (!noBuild && !existsSync(root + "mipsel-sony-psp/psp/lib/libc.a")) {
+  console.error("PSP SDK not found — run `bun run bootstrap` once for this checkout.");
+  process.exit(1);
+}
+
+const targetDir = root + `runtime/target/mipsel-sony-psp/${profile}`;
+const prxPath = targetDir + "/pspjs-runtime.prx";
+
+// usbhostfs_pc binds base..base+8; pspsh talks to base, base+2, base+3, base+8.
+// Default base 10000 is the PSPLINK standard; auto-scan upward for a free block so
+// a squatter on 10000 (e.g. Baidu Netdisk) doesn't break us. Override: PSP_HW_PORT.
+function portFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer();
+    srv.once("error", () => resolve(false));
+    srv.once("listening", () => srv.close(() => resolve(true)));
+    srv.listen(port, "127.0.0.1");
+  });
+}
+async function findBasePort(start: number): Promise<number> {
+  for (let base = start; base <= start + 3000; base += 100) {
+    let ok = true;
+    for (let i = 0; i <= 8; i++) if (!(await portFree(base + i))) { ok = false; break; }
+    if (ok) return base;
+  }
+  throw new Error("no free TCP port block found for the PSPLINK link");
+}
+
+async function build(): Promise<boolean> {
+  if (noBuild) return existsSync(prxPath);
+  if (isFw(game)) await $`bun ${root}framework/build.ts`.quiet().nothrow();
+  console.log(`building ${game} (${profile})…`);
+  const cargoArgs = release ? ["--release"] : [];
+  const res = await $`bun ${root}runtime/build.ts ${cargoArgs}`
+    .env({ ...process.env, PSPJS_GAME: game + ".js" })
+    .nothrow();
+  if (res.exitCode !== 0 || !existsSync(prxPath)) {
+    console.error("build failed — not reloading");
+    return false;
+  }
+  return true;
+}
+
+let connectCount = 0;
+async function pump(stream: ReadableStream<Uint8Array>): Promise<void> {
+  const dec = new TextDecoder();
+  for await (const chunk of stream) {
+    const text = dec.decode(chunk);
+    for (const _ of text.matchAll(/Connected to device/g)) connectCount++;
+  }
+}
+async function waitForConnect(prev: number, timeoutMs = 20000): Promise<boolean> {
+  const t0 = Date.now();
+  while (connectCount <= prev) {
+    if (Date.now() - t0 > timeoutMs) return false;
+    await Bun.sleep(200);
+  }
+  return true;
+}
+
+// reset PSPLINK (clears memory + auto-reconnects USB) then load the fresh .prx.
+async function loadGame(): Promise<void> {
+  const prev = connectCount;
+  process.stdout.write("resetting PSPLINK, waiting for USB reconnect… ");
+  await $`${pspsh} -p ${basePort} -e reset`.nothrow().quiet();
+  if (!(await waitForConnect(prev))) {
+    console.log("timeout.\n  → is the PSP awake and still in PSPLINK? (it sleeps when idle)");
+    return;
+  }
+  console.log("connected.");
+  const out = (await $`${pspsh} -p ${basePort} -e ${"ldstart " + PRX}`.nothrow().text()).trim();
+  console.log("  " + (out || "(no output)"));
+  if (/Failed|Error/i.test(out)) {
+    console.log("  ⚠ load failed — see docs/psp-hardware-debugging.md (Troubleshooting)");
+  }
+}
+
+const proc = { kill() {} } as { kill: () => void };
+let cleaned = false;
+function cleanup(): void {
+  if (cleaned) return;
+  cleaned = true;
+  try { proc.kill(); } catch { /* already gone */ }
+}
+process.on("SIGINT", () => { cleanup(); process.exit(0); });
+
+// ── main ──
+if (!(await build())) process.exit(1);
+
+if (existsSync(root + "runtime/target") === false) {
+  console.error("no build output at " + targetDir);
+  process.exit(1);
+}
+
+const basePort = await findBasePort(Number(process.env.PSP_HW_PORT ?? 10000));
+
+const existing = (await $`pgrep -x usbhostfs_pc`.nothrow().text()).trim();
+if (existing) {
+  console.log(`note: another usbhostfs_pc is running (pid ${existing.split("\n").join(", ")}).`);
+  console.log("      Only one can own the PSP's USB — kill it if the link fails to connect.");
+}
+
+console.log(`serving ${targetDir.replace(root, "")} as host0: on port ${basePort}`);
+const child = Bun.spawn([usbhostfs, "-b", String(basePort), targetDir], { stdout: "pipe", stderr: "pipe" });
+proc.kill = () => child.kill();
+void pump(child.stdout);
+void pump(child.stderr);
+
+console.log("waiting for the PSP… launch PSPLINK on it (XMB → Game → PSPLINK).");
+if (!(await waitForConnect(0, 120000))) {
+  console.error("PSP never connected. Check the USB DATA cable and that PSPLINK is running.");
+  console.error("(`ioreg -p IOUSB | grep -i PSP` should list `\"PSP\" Type B`.)");
+  cleanup();
+  process.exit(1);
+}
+console.log("PSP connected.");
+
+await loadGame();
+
+if (once) {
+  cleanup();
+  process.exit(0);
+}
+
+console.log("\n[psp:hw] press Enter to rebuild + reload  ·  q + Enter to quit\n");
+const rl = createInterface({ input: process.stdin });
+for await (const line of rl) {
+  const cmd = line.trim().toLowerCase();
+  if (cmd === "q" || cmd === "quit" || cmd === "exit") break;
+  if (await build()) await loadGame();
+  console.log("\n[psp:hw] press Enter to rebuild + reload  ·  q + Enter to quit\n");
+}
+rl.close();
+cleanup();
+process.exit(0);


### PR DESCRIPTION
## What

`bun run psp:hw <game>` runs a freshly compiled game on a **real PSP over USB** — no memory-stick copy. It drives the PSPLINK + usbhostfs debug chain so you get a tight edit → build → run loop on real hardware.

```sh
bun run psp:hw walk3d   # build, load onto the PSP, then press Enter to hot-reload
```

- `usbhostfs_pc` serves the cargo output dir to the PSP as `host0:`
- `pspsh` `ldstart`s the raw `pspjs-runtime.prx` through PSPLINK (stays resident)
- Reload = `reset` (clean memory) + `ldstart` (your latest build)

**No env vars.** The script auto-picks a free TCP port block and waits for the USB reconnect after each reset.

## Why these specifics (encoded so you don't hit them)

- Load the raw `.prx`, **not** `EBOOT.PBP` — PSPLINK doesn't unwrap the PBP container → `0x80020148 UNSUPPORTED_PRX_TYPE`.
- `reset` before each reload, **not** `modstun` — rust-psp modules don't free memory on stop → `0x800200D9 MEMBLOCK_ALLOC_FAILED` on the 2nd load.
- Auto-avoid a squatter on the default PSPLINK port 10000 (e.g. Baidu Netdisk).

## Contents

- `scripts/psp-hw.ts` — the wrapper (build + serve + reload loop; `--once`, `--no-build`, `-r`).
- `docs/psp-hardware-debugging.md` — one-time host-tools + PSPLINK setup, usage, troubleshooting, and the manual command equivalent.
- `package.json` `psp:hw` script + README pointer.

## Test

Validated end-to-end on a real PSP (Pro CFW): auto-selected port 10100, detected the PSP, `reset` + reconnect, `ldstart` succeeded, clean exit. Full `bun run psp:hw walk3d --once` (bundle + cargo build + load) also verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)